### PR TITLE
Improve the PatchGuard bypass

### DIFF
--- a/SandboxBootkit/EfiEntry.cpp
+++ b/SandboxBootkit/EfiEntry.cpp
@@ -208,6 +208,30 @@ static void DisableDSE(void* ImageBase, uint64_t ImageSize)
     {
         Die();
     }
+
+    /*
+    nt!SeCodeIntegrityQueryInformation
+    PAGE:00000001406FFB30 48 83 EC 38                             sub     rsp, 38h
+    PAGE:00000001406FFB34 48 83 3D BC DD 51 00 00                 cmp     cs:qword_140C1D8F8, 0
+    PAGE:00000001406FFB3C 4D 8B C8                                mov     r9, r8
+    PAGE:00000001406FFB3F 4C 8B D1                                mov     r10, rcx
+    PAGE:00000001406FFB42 74 2F                                   jz      short loc_1406FFB73
+    */
+    auto SeCodeIntegrityQueryInformation = FIND_PATTERN(PageBase, PageSize, "\x48\x83\xEC\xCC\x48\x83\x3D\xCC\xCC\xCC\xCC\x00\x4D\x8B\xC8\x4C\x8B\xD1\x74");
+    if (SeCodeIntegrityQueryInformation != nullptr)
+    {
+        /*
+        mov dword ptr [r8], 8
+        xor eax, eax
+        mov dword ptr [rcx+4], 1
+        ret
+        */
+        memcpy(SeCodeIntegrityQueryInformation, "\x41\xC7\x00\x08\x00\x00\x00\x33\xC0\xC7\x41\x04\x01\x00\x00\x00\xC3", 17);
+    }
+    else
+    {
+        Die();
+    }
 }
 
 static void HookNtoskrnl(void* ImageBase, uint64_t ImageSize)

--- a/SandboxBootkit/EfiEntry.cpp
+++ b/SandboxBootkit/EfiEntry.cpp
@@ -1,311 +1,5 @@
 #include "Efi.hpp"
-
-static void PatchReturn0(void* Function)
-{
-    memcpy(Function, "\x33\xC0\xC3", 3); // xor eax, eax; ret
-}
-
-static void DisablePatchGuard(void* ImageBase, uint64_t ImageSize)
-{
-    // Find the section ranges because some sections are NOACCESS
-    auto InitSection = FindSection(ImageBase, "INIT");
-    if (InitSection == nullptr)
-    {
-        Die();
-    }
-    auto InitBase = RVA<uint8_t*>(ImageBase, InitSection->VirtualAddress);
-    auto InitSize = InitSection->Misc.VirtualSize;
-
-    auto TextSection = FindSection(ImageBase, ".text");
-    if (TextSection == nullptr)
-    {
-        Die();
-    }
-    auto TextBase = RVA<uint8_t*>(ImageBase, TextSection->VirtualAddress);
-    auto TextSize = TextSection->Misc.VirtualSize;
-
-    // These patch locations are the same as EfiGuard:
-    // https://github.com/Mattiwatti/EfiGuard/blob/25bb182026d24944713e36f129a93d08397de913/EfiGuardDxe/PatchNtoskrnl.c
-
-    /*
-    nt!KeInitAmd64SpecificState
-    INIT:0000000140A4F601 8B C2                  mov     eax, edx
-    INIT:0000000140A4F603 99                     cdq
-    INIT:0000000140A4F604 41 F7 F8               idiv    r8d
-    INIT:0000000140A4F607 89 44 24 30            mov     [rsp+28h+arg_0], eax
-    INIT:0000000140A4F60B EB 00                  jmp     short $+2
-    */
-
-    auto KeInitAmd64SpecificStateJmp = FIND_PATTERN(InitBase, InitSize, "\x8B\xC2\x99\x41\xF7\xF8");
-
-    if (KeInitAmd64SpecificStateJmp != nullptr)
-    {
-        // Prevent the mov from modifying the return address
-        memset(RVA<void*>(KeInitAmd64SpecificStateJmp, 6), 0x90, 4); // nop x4
-    }
-    else
-    {
-        Die();
-    }
-
-    /*
-    nt!KiSwInterrupt
-    .text:00000001403FD24E FB                    sti
-    .text:00000001403FD24F 48 8D 4D 80           lea     rcx, [rbp+0E8h+var_168]
-    .text:00000001403FD253 E8 E8 C2 FD FF        call    KiSwInterruptDispatch
-    .text:00000001403FD258 FA                    cli
-    */
-
-    auto KiSwInterruptDispatchCall = FIND_PATTERN(TextBase, TextSize, "\xFB\x48\x8D\xCC\xCC\xE8\xCC\xCC\xCC\xCC\xFA");
-
-    if (KiSwInterruptDispatchCall != nullptr)
-    {
-        // Prevent KiSwInterruptDispatch from being executed
-        memset(KiSwInterruptDispatchCall, 0x90, 11); // nop x11
-    }
-    else
-    {
-        Die();
-    }
-
-    /*
-    nt!KiVerifyScopesExecute
-    INIT:0000000140A16060 48 8B C4                                      mov     rax, rsp
-    INIT:0000000140A16063 48 89 58 08                                   mov     [rax+8], rbx
-    INIT:0000000140A16067 48 89 70 10                                   mov     [rax+10h], rsi
-    INIT:0000000140A1606B 48 89 78 18                                   mov     [rax+18h], rdi
-    INIT:0000000140A1606F 4C 89 78 20                                   mov     [rax+20h], r15
-    INIT:0000000140A16073 55                                            push    rbp
-    INIT:0000000140A16074 48 8B EC                                      mov     rbp, rsp
-    INIT:0000000140A16077 48 83 EC 60                                   sub     rsp, 60h
-    INIT:0000000140A1607B 83 65 F4 00                                   and     [rbp+var_C], 0
-    INIT:0000000140A1607F 0F 57 C0                                      xorps   xmm0, xmm0
-    We try to find this:
-    INIT:0000000140A16082 48 83 65 E8 00                                and     [rbp+var_18], 0
-    INIT:0000000140A16087 48 B8 FF FF FF FF FF FF FF FE                 mov     rax, 0FEFFFFFFFFFFFFFFh
-    */
-
-    auto KiVerifyScopesExecuteMid = FIND_PATTERN(InitBase, InitSize, "\x48\x83\xCC\xCC\x00\x48\xB8\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE");
-    if (KiVerifyScopesExecuteMid != nullptr)
-    {
-        auto KiVerifyScopesExecute = FindFunctionStart(ImageBase, KiVerifyScopesExecuteMid);
-        if (KiVerifyScopesExecute != nullptr)
-        {
-            PatchReturn0(KiVerifyScopesExecute);
-        }
-        else
-        {
-            Die();
-        }
-    }
-    else
-    {
-        Die();
-    }
-
-    /*
-    nt!KiMcaDeferredRecoveryService
-    .text:00000001401CCA30 33 C0                                         xor     eax, eax
-    .text:00000001401CCA32 8B D8                                         mov     ebx, eax
-    .text:00000001401CCA34 8B F8                                         mov     edi, eax
-    .text:00000001401CCA36 8B E8                                         mov     ebp, eax
-    .text:00000001401CCA38 4C 8B D0                                      mov     r10, rax
-    */
-
-    auto KiMcaDeferredRecoveryService = FIND_PATTERN(TextBase, TextSize, "\x33\xC0\x8B\xD8\x8B\xF8\x8B\xE8\x4C\x8B\xD0");
-    if (KiMcaDeferredRecoveryService != nullptr)
-    {
-        // Find the callers of this function
-        uint8_t* Callers[] = { 0, 0 };
-        for (size_t i = 0, count = 0; i + 5 < TextSize; i++)
-        {
-            auto Address = TextBase + i;
-            if (*Address == 0xE8) // call disp32
-            {
-                auto Displacement = *(int32_t*)(Address + 1);
-                auto CallDestination = Address + Displacement + 5;
-                if (CallDestination == KiMcaDeferredRecoveryService)
-                {
-                    // Skip over the call
-                    i += 4;
-
-                    // There should not be more than two callers
-                    count++;
-                    if (count > 2)
-                    {
-                        Die();
-                    }
-
-                    // Patch out the caller functions at the start
-                    auto CallerFunction = FindFunctionStart(ImageBase, Address);
-                    if (CallerFunction != nullptr)
-                    {
-                        PatchReturn0(CallerFunction);
-                    }
-                    else
-                    {
-                        Die();
-                    }
-                }
-            }
-        }
-    }
-    else
-    {
-        Die();
-    }
-
-    /*
-    nt!CcInitializeBcbProfiler
-    INIT:0000000140A19354 40 55                                         push    rbp
-    INIT:0000000140A19356 53                                            push    rbx
-    INIT:0000000140A19357 56                                            push    rsi
-    INIT:0000000140A19358 57                                            push    rdi
-    INIT:0000000140A19359 41 54                                         push    r12
-    INIT:0000000140A1935B 41 55                                         push    r13
-    INIT:0000000140A1935D 41 56                                         push    r14
-    INIT:0000000140A1935F 41 57                                         push    r15
-    INIT:0000000140A19361 48 8D 6C 24 E1                                lea     rbp, [rsp-1Fh]
-    INIT:0000000140A19366 48 81 EC B8 00 00 00                          sub     rsp, 0B8h
-    INIT:0000000140A1936D 48 B8 D4 02 00 00 80 F7 FF FF                 mov     rax, offset SharedUserData.KdDebuggerEnabled
-    */
-
-    auto CcInitializeBcbProfilerMid = FIND_PATTERN(InitBase, InitSize, "\x48\xB8\xD4\x02\x00\x00\x80\xF7\xFF\xFF");
-    if (CcInitializeBcbProfilerMid != nullptr)
-    {
-        auto CcInitializeBcbProfiler = FindFunctionStart(ImageBase, CcInitializeBcbProfilerMid);
-        if (CcInitializeBcbProfiler != nullptr)
-        {
-            memcpy(CcInitializeBcbProfiler, "\xB0\x01\xC3", 3); // mov al, 1; ret
-        }
-        else
-        {
-            Die();
-        }
-    }
-    else
-    {
-        Die();
-    }
-
-    /*
-    nt!ExpLicenseWatchInitWorker
-    INIT:0000000140A44DF0 48 89 5C 24 08                                mov     [rsp+arg_0], rbx
-    INIT:0000000140A44DF5 48 89 6C 24 10                                mov     [rsp+arg_8], rbp
-    INIT:0000000140A44DFA 48 89 74 24 18                                mov     [rsp+arg_10], rsi
-    INIT:0000000140A44DFF 57                                            push    rdi
-    INIT:0000000140A44E00 48 83 EC 30                                   sub     rsp, 30h
-    INIT:0000000140A44E04 0F AE E8                                      lfence
-    INIT:0000000140A44E07 48 8B 05 B2 8E 2B 00                          mov     rax, cs:KiProcessorBlock
-    INIT:0000000140A44E0E 48 8B 70 78                                   mov     rsi, [rax+78h]
-    INIT:0000000140A44E12 48 8B 68 70                                   mov     rbp, [rax+70h]
-    INIT:0000000140A44E16 48 83 60 78 00                                and     qword ptr [rax+78h], 0
-    INIT:0000000140A44E1B 48 83 60 70 00                                and     qword ptr [rax+70h], 0
-    INIT:0000000140A44E20 A0 D4 02 00 00 80 F7 FF FF                    mov     al, ds:SharedUserData.KdDebuggerEnabled
-    */
-
-    auto ExpLicenseWatchInitWorkerMid = FIND_PATTERN(InitBase, InitSize, "\x48\xB8\xD4\x02\x00\x00\x80\xF7\xFF\xFF");
-    if (ExpLicenseWatchInitWorkerMid != nullptr)
-    {
-        auto ExpLicenseWatchInitWorker = FindFunctionStart(ImageBase, ExpLicenseWatchInitWorkerMid);
-        if (ExpLicenseWatchInitWorker != nullptr)
-        {
-            PatchReturn0(ExpLicenseWatchInitWorker);
-        }
-        else
-        {
-            Die();
-        }
-    }
-    else
-    {
-        Die();
-    }
-}
-
-static void DisableDSE(void* ImageBase, uint64_t ImageSize)
-{
-    auto PageSection = FindSection(ImageBase, "PAGE");
-    if (PageSection == nullptr)
-    {
-        Die();
-    }
-    auto PageBase = RVA<uint8_t*>(ImageBase, PageSection->VirtualAddress);
-    auto PageSize = PageSection->Misc.VirtualSize;
-
-    /*
-    nt!SepInitializeCodeIntegrity
-    PAGE:0000000140799EBB 4C 8D 05 DE 39 48 00   lea     r8, SeCiCallbacks
-    PAGE:0000000140799EC2 8B CF                  mov     ecx, edi
-    PAGE:0000000140799EC4 48 FF 15 95 71 99 FF   call    cs:__imp_CiInitialize
-    */
-
-    auto CiInitializeCall = FIND_PATTERN(PageBase, PageSize, "\x4C\x8D\x05\xCC\xCC\xCC\xCC\x8B\xCF");
-
-    if (CiInitializeCall != nullptr)
-    {
-        // Change CodeIntegrityOptions to zero for CiInitialize call
-        *RVA<uint16_t*>(CiInitializeCall, 7) = 0xC931; // xor ecx, ecx
-    }
-    else
-    {
-        Die();
-    }
-
-    /*
-    nt!SeValidateImageData
-    PAGE:00000001406EBD15                  loc_1406EBD15:
-    PAGE:00000001406EBD15 48 83 C4 48            add     rsp, 48h
-    PAGE:00000001406EBD19 C3                     retn
-    PAGE:00000001406EBD1A CC                     db 0CCh
-    PAGE:00000001406EBD1B                  loc_1406EBD1B:
-    PAGE:00000001406EBD1B B8 28 04 00 C0         mov     eax, 0C0000428h
-    PAGE:00000001406EBD20 EB F3                  jmp     short loc_1406EBD15
-    PAGE:00000001406EBD20                  SeValidateImageData endp
-    */
-
-    auto SeValidateImageDataRet = FIND_PATTERN(PageBase, PageSize, "\x48\x83\xC4\x48\xC3\xCC\xB8\x28\x04\x00\xC0");
-
-    if (SeValidateImageDataRet != nullptr)
-    {
-        // Ensure SeValidateImageData returns a success status
-        *RVA<uint32_t*>(SeValidateImageDataRet, 7) = 0; // mov eax, 0
-    }
-    else
-    {
-        Die();
-    }
-
-    /*
-    nt!SeCodeIntegrityQueryInformation
-    PAGE:00000001406FFB30 48 83 EC 38                             sub     rsp, 38h
-    PAGE:00000001406FFB34 48 83 3D BC DD 51 00 00                 cmp     cs:qword_140C1D8F8, 0
-    PAGE:00000001406FFB3C 4D 8B C8                                mov     r9, r8
-    PAGE:00000001406FFB3F 4C 8B D1                                mov     r10, rcx
-    PAGE:00000001406FFB42 74 2F                                   jz      short loc_1406FFB73
-    */
-    auto SeCodeIntegrityQueryInformation = FIND_PATTERN(PageBase, PageSize, "\x48\x83\xEC\xCC\x48\x83\x3D\xCC\xCC\xCC\xCC\x00\x4D\x8B\xC8\x4C\x8B\xD1\x74");
-    if (SeCodeIntegrityQueryInformation != nullptr)
-    {
-        /*
-        mov dword ptr [r8], 8
-        xor eax, eax
-        mov dword ptr [rcx+4], 1
-        ret
-        */
-        memcpy(SeCodeIntegrityQueryInformation, "\x41\xC7\x00\x08\x00\x00\x00\x33\xC0\xC7\x41\x04\x01\x00\x00\x00\xC3", 17);
-    }
-    else
-    {
-        Die();
-    }
-}
-
-static void HookNtoskrnl(void* ImageBase, uint64_t ImageSize)
-{
-    DisablePatchGuard(ImageBase, ImageSize);
-    DisableDSE(ImageBase, ImageSize);
-}
+#include "PatchNtoskrnl.hpp"
 
 static bool IsNtoskrnl(const wchar_t* ImageName)
 {
@@ -335,10 +29,10 @@ static EFI_STATUS BlImgLoadPEImageExHook(void* a1, void* a2, wchar_t* LoadFile, 
 
     DetourCreate(BlImgLoadPEImageEx, BlImgLoadPEImageExHook, BlImgLoadPEImageExOriginal);
 
-    // Check if loaded file is ntoskrnl and hook it
+    // Check if loaded file is ntoskrnl and patch it
     if (!EFI_ERROR(Status) && IsNtoskrnl(LoadFile))
     {
-        HookNtoskrnl(*ImageBase, *ImageSize);
+        PatchNtoskrnl(*ImageBase, *ImageSize);
     }
 
     return Status;
@@ -396,24 +90,13 @@ static void PatchSelfIntegrity(void* ImageBase, uint64_t ImageSize)
     .text:000000001002AE82 83 4D 38 FF           or      [rbp+arg_0], 0FFFFFFFFh
     .text:000000001002AE86 83 4D 40 FF           or      [rbp+a1], 0FFFFFFFFh
     */
-
     auto VerifySelfIntegrityMid = FIND_PATTERN(ImageBase, ImageSize, "\x83\x4D\xCC\xFF\x83\x4D\xCC\xFF");
-    if (VerifySelfIntegrityMid != nullptr)
-    {
-        auto BmFwVerifySelfIntegrity = FindFunctionStart(ImageBase, VerifySelfIntegrityMid);
-        if (BmFwVerifySelfIntegrity != nullptr)
-        {
-            memcpy(BmFwVerifySelfIntegrity, "\x33\xC0\xC3", 3); // xor eax, eax; ret
-        }
-        else
-        {
-            Die();
-        }
-    }
-    else
-    {
-        Die();
-    }
+    ASSERT(VerifySelfIntegrityMid != nullptr);
+
+    auto BmFwVerifySelfIntegrity = FindFunctionStart(ImageBase, VerifySelfIntegrityMid);
+    ASSERT(BmFwVerifySelfIntegrity != nullptr);
+
+    PatchReturn0(BmFwVerifySelfIntegrity);
 }
 
 static EFI_STATUS LoadBootManager()
@@ -421,7 +104,6 @@ static EFI_STATUS LoadBootManager()
     // Query bootmgfw from the filesystem
     EFI_DEVICE_PATH* BootmgfwPath = nullptr;
     auto Status = EfiQueryDevicePath(L"\\EFI\\Microsoft\\Boot\\bootmgfw.efi", &BootmgfwPath);
-
     if (EFI_ERROR(Status))
     {
         return Status;
@@ -431,7 +113,6 @@ static EFI_STATUS LoadBootManager()
     EFI_HANDLE BootmgfwHandle = nullptr;
     Status = gBS->LoadImage(TRUE, gImageHandle, BootmgfwPath, nullptr, 0, &BootmgfwHandle);
     gBS->FreePool(BootmgfwPath);
-
     if (EFI_ERROR(Status))
     {
         return Status;
@@ -442,7 +123,6 @@ static EFI_STATUS LoadBootManager()
 
     // Start the boot manager
     Status = gBS->StartImage(BootmgfwHandle, nullptr, nullptr);
-
     if (EFI_ERROR(Status))
     {
         gBS->UnloadImage(BootmgfwHandle);

--- a/SandboxBootkit/EfiEntry.cpp
+++ b/SandboxBootkit/EfiEntry.cpp
@@ -192,10 +192,7 @@ static void PatchSelfIntegrity(void* ImageBase, uint64_t ImageSize)
     auto VerifySelfIntegrityMid = FIND_PATTERN(ImageBase, ImageSize, "\x83\x4D\xCC\xFF\x83\x4D\xCC\xFF");
     if (VerifySelfIntegrityMid != nullptr)
     {
-        // Find the function start (NOTE: would be cleaner to use the RUNTIME_FUNCTION in the exception directory)
-        // mov [rsp+8], ecx
-        constexpr auto WalkBack = 0x30;
-        auto BmFwVerifySelfIntegrity = FIND_PATTERN(VerifySelfIntegrityMid - WalkBack, WalkBack, "\x89\x4C\x24\x08");
+        auto BmFwVerifySelfIntegrity = FindFunctionStart(ImageBase, VerifySelfIntegrityMid);
         if (BmFwVerifySelfIntegrity != nullptr)
         {
             memcpy(BmFwVerifySelfIntegrity, "\x33\xC0\xC3", 3); // xor eax, eax; ret

--- a/SandboxBootkit/EfiUtils.cpp
+++ b/SandboxBootkit/EfiUtils.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "Efi.hpp"
 
 EFI_IMAGE_NT_HEADERS64* GetNtHeaders(void* ImageBase)
@@ -92,6 +94,7 @@ void* GetExport(void* ImageBase, const char* FunctionName, const char* ModuleNam
 
 bool FixRelocations(void* ImageBase, uint64_t ImageBaseDelta)
 {
+    // Check if relocations are already applied to the image
     if (ImageBaseDelta == 0)
     {
         return true;
@@ -145,6 +148,57 @@ bool FixRelocations(void* ImageBase, uint64_t ImageBaseDelta)
     }
 
     return true;
+}
+
+struct RUNTIME_FUNCTION
+{
+    uint32_t BeginAddress;
+    uint32_t EndAddress;
+    uint32_t UnwindInfo;
+};
+
+#define RUNTIME_FUNCTION_INDIRECT 0x1
+
+uint8_t* FindFunctionStart(void* ImageBase, void* Address)
+{
+    auto NtHeaders = GetNtHeaders(ImageBase);
+    if (NtHeaders == nullptr)
+    {
+        return nullptr;
+    }
+
+    auto ExceptionDirectory = &NtHeaders->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_EXCEPTION];
+    if (ExceptionDirectory->VirtualAddress == 0 || ExceptionDirectory->Size == 0)
+    {
+        return nullptr;
+    }
+
+    // Do a binary search to find the RUNTIME_FUNCTION
+    auto Rva = (uint32_t)((uint8_t*)Address - (uint8_t*)ImageBase);
+    auto Begin = RVA<RUNTIME_FUNCTION*>(ImageBase, ExceptionDirectory->VirtualAddress);
+    auto End = Begin + ExceptionDirectory->Size / sizeof(RUNTIME_FUNCTION);
+    auto FoundEntry = std::lower_bound(Begin, End, Rva, [](const RUNTIME_FUNCTION& Entry, uint32_t Rva)
+        {
+            return Entry.EndAddress < Rva;
+        });
+
+    // Make sure the found entry is in-range
+    // See: https://en.cppreference.com/w/cpp/algorithm/lower_bound
+    if (FoundEntry == End || Rva < FoundEntry->BeginAddress)
+    {
+        return nullptr;
+    }
+
+    // Resolve indirect function entries back to the owning entry
+    // See: https://github.com/dotnet/runtime/blob/d5e3a5c2ca46691d65c81d520cb95f13f7a94652/src/coreclr/vm/codeman.cpp#L4403-L4416
+    // As a sidenote, this seems to be why functions addresses have to be aligned?
+    if ((FoundEntry->UnwindInfo & RUNTIME_FUNCTION_INDIRECT) != 0)
+    {
+        auto OwningEntryRva = FoundEntry->UnwindInfo - RUNTIME_FUNCTION_INDIRECT;
+        FoundEntry = RVA<RUNTIME_FUNCTION*>(ImageBase, OwningEntryRva);
+    }
+
+    return RVA<uint8_t*>(ImageBase, FoundEntry->BeginAddress);
 }
 
 bool ComparePattern(uint8_t* Base, uint8_t* Pattern, size_t PatternLen)

--- a/SandboxBootkit/EfiUtils.hpp
+++ b/SandboxBootkit/EfiUtils.hpp
@@ -49,8 +49,9 @@ void* FindImageBase(uint64_t Address, size_t MaxSize = (1 * 1024 * 1024));
 void* GetExport(void* ImageBase, const char* FunctionName, const char* ModuleName = nullptr);
 bool FixRelocations(void* ImageBase, uint64_t ImageBaseDelta);
 uint8_t* FindFunctionStart(void* ImageBase, void* Address);
+EFI_IMAGE_SECTION_HEADER* FindSection(void* ImageBase, const char* SectionName);
 bool ComparePattern(uint8_t* Base, uint8_t* Pattern, size_t PatternLen);
 uint8_t* FindPattern(uint8_t* Base, size_t Size, uint8_t* Pattern, size_t PatternLen);
-void Die();
+void __declspec(noreturn) Die();
 
 #define FIND_PATTERN(Base, Size, Pattern) FindPattern((uint8_t*)Base, Size, (uint8_t*)Pattern, ARRAY_SIZE(Pattern) - 1);

--- a/SandboxBootkit/EfiUtils.hpp
+++ b/SandboxBootkit/EfiUtils.hpp
@@ -48,6 +48,7 @@ EFI_IMAGE_NT_HEADERS64* GetNtHeaders(void* ImageBase);
 void* FindImageBase(uint64_t Address, size_t MaxSize = (1 * 1024 * 1024));
 void* GetExport(void* ImageBase, const char* FunctionName, const char* ModuleName = nullptr);
 bool FixRelocations(void* ImageBase, uint64_t ImageBaseDelta);
+uint8_t* FindFunctionStart(void* ImageBase, void* Address);
 bool ComparePattern(uint8_t* Base, uint8_t* Pattern, size_t PatternLen);
 uint8_t* FindPattern(uint8_t* Base, size_t Size, uint8_t* Pattern, size_t PatternLen);
 void Die();

--- a/SandboxBootkit/EfiUtils.hpp
+++ b/SandboxBootkit/EfiUtils.hpp
@@ -54,4 +54,10 @@ bool ComparePattern(uint8_t* Base, uint8_t* Pattern, size_t PatternLen);
 uint8_t* FindPattern(uint8_t* Base, size_t Size, uint8_t* Pattern, size_t PatternLen);
 void __declspec(noreturn) Die();
 
+#define ASSERT(Condition) \
+    if (!(Condition))     \
+    {                     \
+        Die();            \
+    }
+
 #define FIND_PATTERN(Base, Size, Pattern) FindPattern((uint8_t*)Base, Size, (uint8_t*)Pattern, ARRAY_SIZE(Pattern) - 1);

--- a/SandboxBootkit/PatchNtoskrnl.cpp
+++ b/SandboxBootkit/PatchNtoskrnl.cpp
@@ -1,0 +1,221 @@
+#include "PatchNtoskrnl.hpp"
+
+void PatchReturn0(void* Function)
+{
+    memcpy(Function, "\x33\xC0\xC3", 3); // xor eax, eax; ret
+}
+
+static void DisablePatchGuard(void* ImageBase, uint64_t ImageSize)
+{
+    // Find the section ranges because some sections are NOACCESS
+    auto InitSection = FindSection(ImageBase, "INIT");
+    ASSERT(InitSection != nullptr);
+
+    auto InitBase = RVA<uint8_t*>(ImageBase, InitSection->VirtualAddress);
+    auto InitSize = InitSection->Misc.VirtualSize;
+
+    auto TextSection = FindSection(ImageBase, ".text");
+    ASSERT(TextSection != nullptr);
+
+    auto TextBase = RVA<uint8_t*>(ImageBase, TextSection->VirtualAddress);
+    auto TextSize = TextSection->Misc.VirtualSize;
+
+    /*
+    nt!KeInitAmd64SpecificState
+    INIT:0000000140A4F601 8B C2                  mov     eax, edx
+    INIT:0000000140A4F603 99                     cdq
+    INIT:0000000140A4F604 41 F7 F8               idiv    r8d
+    INIT:0000000140A4F607 89 44 24 30            mov     [rsp+28h+arg_0], eax
+    INIT:0000000140A4F60B EB 00                  jmp     short $+2
+    */
+    auto KeInitAmd64SpecificStateJmp = FIND_PATTERN(InitBase, InitSize, "\x8B\xC2\x99\x41\xF7\xF8");
+    ASSERT(KeInitAmd64SpecificStateJmp != nullptr);
+
+    // Prevent the mov from modifying the return address
+    memset(RVA<void*>(KeInitAmd64SpecificStateJmp, 6), 0x90, 4); // nop x4
+
+    /*
+    nt!KiSwInterrupt
+    .text:00000001403FD24E FB                    sti
+    .text:00000001403FD24F 48 8D 4D 80           lea     rcx, [rbp+0E8h+var_168]
+    .text:00000001403FD253 E8 E8 C2 FD FF        call    KiSwInterruptDispatch
+    .text:00000001403FD258 FA                    cli
+    */
+    auto KiSwInterruptDispatchCall = FIND_PATTERN(TextBase, TextSize, "\xFB\x48\x8D\xCC\xCC\xE8\xCC\xCC\xCC\xCC\xFA");
+    ASSERT(KiSwInterruptDispatchCall != nullptr);
+
+    // Prevent KiSwInterruptDispatch from being executed
+    memset(KiSwInterruptDispatchCall, 0x90, 11); // nop x11
+
+    /*
+    nt!KiVerifyScopesExecute
+    INIT:0000000140A16060 48 8B C4                                      mov     rax, rsp
+    INIT:0000000140A16063 48 89 58 08                                   mov     [rax+8], rbx
+    INIT:0000000140A16067 48 89 70 10                                   mov     [rax+10h], rsi
+    INIT:0000000140A1606B 48 89 78 18                                   mov     [rax+18h], rdi
+    INIT:0000000140A1606F 4C 89 78 20                                   mov     [rax+20h], r15
+    INIT:0000000140A16073 55                                            push    rbp
+    INIT:0000000140A16074 48 8B EC                                      mov     rbp, rsp
+    INIT:0000000140A16077 48 83 EC 60                                   sub     rsp, 60h
+    INIT:0000000140A1607B 83 65 F4 00                                   and     [rbp+var_C], 0
+    INIT:0000000140A1607F 0F 57 C0                                      xorps   xmm0, xmm0
+    We try to find this:
+    INIT:0000000140A16082 48 83 65 E8 00                                and     [rbp+var_18], 0
+    INIT:0000000140A16087 48 B8 FF FF FF FF FF FF FF FE                 mov     rax, 0FEFFFFFFFFFFFFFFh
+    */
+    auto KiVerifyScopesExecuteMid = FIND_PATTERN(InitBase, InitSize, "\x48\x83\xCC\xCC\x00\x48\xB8\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE");
+    ASSERT(KiVerifyScopesExecuteMid != nullptr);
+
+    auto KiVerifyScopesExecute = FindFunctionStart(ImageBase, KiVerifyScopesExecuteMid);
+    ASSERT(KiVerifyScopesExecute != nullptr);
+
+    PatchReturn0(KiVerifyScopesExecute);
+
+    /*
+    nt!KiMcaDeferredRecoveryService
+    .text:00000001401CCA30 33 C0                                         xor     eax, eax
+    .text:00000001401CCA32 8B D8                                         mov     ebx, eax
+    .text:00000001401CCA34 8B F8                                         mov     edi, eax
+    .text:00000001401CCA36 8B E8                                         mov     ebp, eax
+    .text:00000001401CCA38 4C 8B D0                                      mov     r10, rax
+    */
+    auto KiMcaDeferredRecoveryService = FIND_PATTERN(TextBase, TextSize, "\x33\xC0\x8B\xD8\x8B\xF8\x8B\xE8\x4C\x8B\xD0");
+    ASSERT(KiMcaDeferredRecoveryService != nullptr);
+
+    // Find the callers of this function
+    uint8_t* Callers[] = { 0, 0 };
+    for (size_t i = 0, Count = 0; i + 5 < TextSize; i++)
+    {
+        auto Address = TextBase + i;
+        if (*Address == 0xE8) // call disp32
+        {
+            auto Displacement = *(int32_t*)(Address + 1);
+            auto CallDestination = Address + Displacement + 5;
+            if (CallDestination == KiMcaDeferredRecoveryService)
+            {
+                // Skip over the call
+                i += 4;
+
+                // There should not be more than two callers
+                Count++;
+                ASSERT(Count <= 2);
+
+                // Patch out the caller functions at the start
+                auto CallerFunction = FindFunctionStart(ImageBase, Address);
+                ASSERT(CallerFunction != nullptr);
+
+                PatchReturn0(CallerFunction);
+            }
+        }
+    }
+
+    /*
+    nt!CcInitializeBcbProfiler
+    INIT:0000000140A19354 40 55                                         push    rbp
+    INIT:0000000140A19356 53                                            push    rbx
+    INIT:0000000140A19357 56                                            push    rsi
+    INIT:0000000140A19358 57                                            push    rdi
+    INIT:0000000140A19359 41 54                                         push    r12
+    INIT:0000000140A1935B 41 55                                         push    r13
+    INIT:0000000140A1935D 41 56                                         push    r14
+    INIT:0000000140A1935F 41 57                                         push    r15
+    INIT:0000000140A19361 48 8D 6C 24 E1                                lea     rbp, [rsp-1Fh]
+    INIT:0000000140A19366 48 81 EC B8 00 00 00                          sub     rsp, 0B8h
+    INIT:0000000140A1936D 48 B8 D4 02 00 00 80 F7 FF FF                 mov     rax, offset SharedUserData.KdDebuggerEnabled
+    */
+    auto CcInitializeBcbProfilerMid = FIND_PATTERN(InitBase, InitSize, "\x48\xB8\xD4\x02\x00\x00\x80\xF7\xFF\xFF");
+    ASSERT(CcInitializeBcbProfilerMid != nullptr);
+
+    auto CcInitializeBcbProfiler = FindFunctionStart(ImageBase, CcInitializeBcbProfilerMid);
+    ASSERT(CcInitializeBcbProfiler != nullptr);
+
+    memcpy(CcInitializeBcbProfiler, "\xB0\x01\xC3", 3); // mov al, 1; ret
+
+    /*
+    nt!ExpLicenseWatchInitWorker
+    INIT:0000000140A44DF0 48 89 5C 24 08                                mov     [rsp+arg_0], rbx
+    INIT:0000000140A44DF5 48 89 6C 24 10                                mov     [rsp+arg_8], rbp
+    INIT:0000000140A44DFA 48 89 74 24 18                                mov     [rsp+arg_10], rsi
+    INIT:0000000140A44DFF 57                                            push    rdi
+    INIT:0000000140A44E00 48 83 EC 30                                   sub     rsp, 30h
+    INIT:0000000140A44E04 0F AE E8                                      lfence
+    INIT:0000000140A44E07 48 8B 05 B2 8E 2B 00                          mov     rax, cs:KiProcessorBlock
+    INIT:0000000140A44E0E 48 8B 70 78                                   mov     rsi, [rax+78h]
+    INIT:0000000140A44E12 48 8B 68 70                                   mov     rbp, [rax+70h]
+    INIT:0000000140A44E16 48 83 60 78 00                                and     qword ptr [rax+78h], 0
+    INIT:0000000140A44E1B 48 83 60 70 00                                and     qword ptr [rax+70h], 0
+    INIT:0000000140A44E20 A0 D4 02 00 00 80 F7 FF FF                    mov     al, ds:SharedUserData.KdDebuggerEnabled
+    */
+    auto ExpLicenseWatchInitWorkerMid = FIND_PATTERN(InitBase, InitSize, "\x48\xB8\xD4\x02\x00\x00\x80\xF7\xFF\xFF");
+    ASSERT(ExpLicenseWatchInitWorkerMid != nullptr);
+
+    auto ExpLicenseWatchInitWorker = FindFunctionStart(ImageBase, ExpLicenseWatchInitWorkerMid);
+    ASSERT(ExpLicenseWatchInitWorker != nullptr);
+
+    PatchReturn0(ExpLicenseWatchInitWorker);
+}
+
+static void DisableDSE(void* ImageBase, uint64_t ImageSize)
+{
+    auto PageSection = FindSection(ImageBase, "PAGE");
+    ASSERT(PageSection != nullptr);
+
+    auto PageBase = RVA<uint8_t*>(ImageBase, PageSection->VirtualAddress);
+    auto PageSize = PageSection->Misc.VirtualSize;
+
+    /*
+    nt!SepInitializeCodeIntegrity
+    PAGE:0000000140799EBB 4C 8D 05 DE 39 48 00   lea     r8, SeCiCallbacks
+    PAGE:0000000140799EC2 8B CF                  mov     ecx, edi
+    PAGE:0000000140799EC4 48 FF 15 95 71 99 FF   call    cs:__imp_CiInitialize
+    */
+    auto CiInitializeCall = FIND_PATTERN(PageBase, PageSize, "\x4C\x8D\x05\xCC\xCC\xCC\xCC\x8B\xCF");
+    ASSERT(CiInitializeCall != nullptr);
+
+    // Change CodeIntegrityOptions to zero for CiInitialize call
+    *RVA<uint16_t*>(CiInitializeCall, 7) = 0xC931; // xor ecx, ecx
+
+    /*
+    nt!SeValidateImageData
+    PAGE:00000001406EBD15                  loc_1406EBD15:
+    PAGE:00000001406EBD15 48 83 C4 48            add     rsp, 48h
+    PAGE:00000001406EBD19 C3                     retn
+    PAGE:00000001406EBD1A CC                     db 0CCh
+    PAGE:00000001406EBD1B                  loc_1406EBD1B:
+    PAGE:00000001406EBD1B B8 28 04 00 C0         mov     eax, 0C0000428h
+    PAGE:00000001406EBD20 EB F3                  jmp     short loc_1406EBD15
+    PAGE:00000001406EBD20                  SeValidateImageData endp
+    */
+    auto SeValidateImageDataRet = FIND_PATTERN(PageBase, PageSize, "\x48\x83\xC4\x48\xC3\xCC\xB8\x28\x04\x00\xC0");
+    ASSERT(SeValidateImageDataRet != nullptr);
+
+    // Ensure SeValidateImageData returns a success status
+    *RVA<uint32_t*>(SeValidateImageDataRet, 7) = 0; // mov eax, 0
+
+    /*
+    nt!SeCodeIntegrityQueryInformation
+    PAGE:00000001406FFB30 48 83 EC 38                             sub     rsp, 38h
+    PAGE:00000001406FFB34 48 83 3D BC DD 51 00 00                 cmp     cs:qword_140C1D8F8, 0
+    PAGE:00000001406FFB3C 4D 8B C8                                mov     r9, r8
+    PAGE:00000001406FFB3F 4C 8B D1                                mov     r10, rcx
+    PAGE:00000001406FFB42 74 2F                                   jz      short loc_1406FFB73
+    */
+    auto SeCodeIntegrityQueryInformation = FIND_PATTERN(PageBase, PageSize, "\x48\x83\xEC\xCC\x48\x83\x3D\xCC\xCC\xCC\xCC\x00\x4D\x8B\xC8\x4C\x8B\xD1\x74");
+    ASSERT(SeCodeIntegrityQueryInformation != nullptr);
+
+    /*
+    mov dword ptr [r8], 8
+    xor eax, eax
+    mov dword ptr [rcx+4], 1
+    ret
+    */
+    memcpy(SeCodeIntegrityQueryInformation, "\x41\xC7\x00\x08\x00\x00\x00\x33\xC0\xC7\x41\x04\x01\x00\x00\x00\xC3", 17);
+}
+
+void PatchNtoskrnl(void* ImageBase, uint64_t ImageSize)
+{
+    // These patch locations are the same as EfiGuard:
+    // https://github.com/Mattiwatti/EfiGuard/blob/25bb182026d24944713e36f129a93d08397de913/EfiGuardDxe/PatchNtoskrnl.c
+    DisablePatchGuard(ImageBase, ImageSize);
+    DisableDSE(ImageBase, ImageSize);
+}

--- a/SandboxBootkit/PatchNtoskrnl.cpp
+++ b/SandboxBootkit/PatchNtoskrnl.cpp
@@ -83,7 +83,7 @@ static void DisablePatchGuard(void* ImageBase, uint64_t ImageSize)
     ASSERT(KiMcaDeferredRecoveryService != nullptr);
 
     // Find the callers of this function
-    uint8_t* Callers[] = { 0, 0 };
+    int CallerCount = 0;
     for (size_t i = 0, Count = 0; i + 5 < TextSize; i++)
     {
         auto Address = TextBase + i;
@@ -97,8 +97,7 @@ static void DisablePatchGuard(void* ImageBase, uint64_t ImageSize)
                 i += 4;
 
                 // There should not be more than two callers
-                Count++;
-                ASSERT(Count <= 2);
+                CallerCount++;
 
                 // Patch out the caller functions at the start
                 auto CallerFunction = FindFunctionStart(ImageBase, Address);
@@ -108,6 +107,7 @@ static void DisablePatchGuard(void* ImageBase, uint64_t ImageSize)
             }
         }
     }
+    ASSERT(CallerCount == 2);
 
     /*
     nt!CcInitializeBcbProfiler

--- a/SandboxBootkit/PatchNtoskrnl.hpp
+++ b/SandboxBootkit/PatchNtoskrnl.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "Efi.hpp"
+
+void PatchReturn0(void* Function);
+void PatchNtoskrnl(void* ImageBase, uint64_t ImageSize);

--- a/SandboxBootkit/SandboxBootkit.vcxproj
+++ b/SandboxBootkit/SandboxBootkit.vcxproj
@@ -79,10 +79,12 @@ if exist "$(OutDir)custom-deploy.cmd" (
     <ClCompile Include="Efi.cpp" />
     <ClCompile Include="EfiEntry.cpp" />
     <ClCompile Include="EfiUtils.cpp" />
+    <ClCompile Include="PatchNtoskrnl.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Efi.hpp" />
     <ClInclude Include="EfiUtils.hpp" />
+    <ClInclude Include="PatchNtoskrnl.hpp" />
     <ClInclude Include="ProcessorBind.hpp" />
   </ItemGroup>
   <ItemGroup>

--- a/SandboxBootkit/SandboxBootkit.vcxproj
+++ b/SandboxBootkit/SandboxBootkit.vcxproj
@@ -65,6 +65,12 @@
     "$(OutDir)Injector.exe" "$(OutDir)bootmgfw.bak" "$(TargetPath)" "$(OutDir)bootmgfw.efi"
 ) else (
     echo You need to copy bootmgfw.bak next to SandboxBootkit.efi for automatic injection
+)
+if exist "$(OutDir)custom-deploy.cmd" (
+    cd "$(OutDir)"
+    call "$(OutDir)custom-deploy.cmd"
+) else (
+    echo No custom-deploy.cmd found, skipping...
 )</Command>
     </PostBuildEvent>
     <PostBuildEvent />

--- a/SandboxBootkit/SandboxBootkit.vcxproj.filters
+++ b/SandboxBootkit/SandboxBootkit.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="EfiUtils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="PatchNtoskrnl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Efi.hpp">
@@ -33,6 +36,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="ProcessorBind.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="PatchNtoskrnl.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
- After a lot of research and testing @mgoodings found a PatchGuard bypass that actually seems to work. Initially I tried doing all the same patches EfiGuard does, but this isn't enough in Windows Sandbox. For unknown reasons a regular Hyper-V VM works fine. It seems that PG has changed quite a bit, there is a good reference [here](https://blog.tetrane.com/downloads/Tetrane_PatchGuard_Analysis_RS4_v1.01.pdf).
- There was an issue when trying to iterate the whole `ImageSize` of `ntoskrnl.exe` (likely because there are gaps between the sections that are not mapped) so I changed to using section ranges instead.
- Since the amount of patches increased I moved the ntoskrnl patches to a separate file to keep the main bootkit simple.